### PR TITLE
패스워드를 잊어버렸습니다

### DIFF
--- a/src/main/java/com/study/account/AccountController.java
+++ b/src/main/java/com/study/account/AccountController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.validation.Valid;
 import java.time.LocalDateTime;
@@ -121,4 +122,49 @@ public class AccountController {
         return "account/profile";
     }
 
+
+    @GetMapping("/email-login")
+    public String emailLoginForm(String email, Model model, RedirectAttributes attributes) {
+
+        return "account/email-login";
+
+    }
+
+    @PostMapping("/email-login")
+    public String sendEmailLoginLink(String email, Model model, RedirectAttributes attributes) {
+
+        Account account = accountRepository.findByEmail(email);
+
+
+        if (account == null) {
+            model.addAttribute("error", "유효한 이메일 주소가 아닙니다.");
+            return "account/email-login";
+        }
+
+        if (!account.canSendConfirmEmail()) {
+            model.addAttribute("error", "이메일 로그인은 1시간 뒤에 사용할 수 있습니다.");
+//            return "account/email-login";
+        }
+
+        accountService.sendLoginLink(account);
+        attributes.addFlashAttribute("message", "이메일 인증 메일을 전송하였습니다.");
+
+
+        return "redirect:/email-login";
+
+    }
+
+    @GetMapping("login-by-email")
+    public String loginByEmail(String token, String email, Model model) {
+        Account account = accountRepository.findByEmail(email);
+
+        String view = "account/logged-in-by-email";
+
+        if (account == null || !account.isValidToken(token)) {
+            model.addAttribute("error", "로그인할 수 있습니다.");
+            return view;
+        }
+        accountService.login(account);
+        return view;
+    }
 }

--- a/src/main/java/com/study/account/AccountService.java
+++ b/src/main/java/com/study/account/AccountService.java
@@ -120,4 +120,14 @@ public class AccountService implements UserDetailsService {
         accountRepository.save(account);
         login(account);
     }
+
+    public void sendLoginLink(Account account) {
+        account.generateEmailCheckToken();
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+        mailMessage.setTo(account.getEmail());
+        mailMessage.setSubject("스터디올래, 로그인 링크");
+        mailMessage.setText("/login-by-email?token=" + account.getEmailCheckToken() +
+                "&email=" + account.getEmail());
+        javaMailSender.send(mailMessage);
+    }
 }

--- a/src/main/java/com/study/config/SecurityConfig.java
+++ b/src/main/java/com/study/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
                 .mvcMatchers("/", "/login", "/sign-up", "/check-email", "/check-email-token",
-                        "/email-login", "/check-email-login", "/login-link").permitAll()
+                        "/email-login", "/check-email-login", "/login-link", "login-by-email").permitAll()
                 .mvcMatchers(HttpMethod.GET, "/profile/*").permitAll()
                 .anyRequest().authenticated();
 

--- a/src/main/resources/templates/account/check-login-email.html
+++ b/src/main/resources/templates/account/check-login-email.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments.html :: head"></head>
+<body class="bg-light">
+    <nav th:replace="fragments.html :: main-nav"></nav>
+
+    <div class="container">
+        <div class="py-5 text-center" th:if="${error}">
+            <p class="lead">스터디올래 이메일 로그인</p>
+            <div  class="alert alert-danger" role="alert">
+                이메일이 정확하지 않거나 가입하지 않은 이메일 입니다.
+            </div>
+            <p class="lead" th:text="${email}">your@email.com</p>
+        </div>
+
+        <div class="py-5 text-center" th:if="${error == null}">
+            <p class="lead">스터디올래 이메일 로그인</p>
+
+            <h2>이메일을 확인하세요. 로그인 링크를 보냈습니다.</h2>
+            <p class="lead" th:text="${email}">your@email.com</p>
+            <small class="text-info">이메일을 확인해야 로그인 할 수 있습니다.</small>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/account/email-login.html
+++ b/src/main/resources/templates/account/email-login.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments.html :: head"></head>
+<body class="bg-light">
+    <div th:replace="fragments.html :: main-nav"></div>
+    <div class="container">
+        <div class="py-5 text-center">
+            <p class="lead">스터디올래</p>
+            <h2>패스워드 없이 로그인하기</h2>
+        </div>
+        <div class="row justify-content-center">
+            <div th:if="${error}" class="alert alert-danger alert-dismissible fade show mt-3" role="alert">
+                <span th:text="${error}">완료</span>
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+
+            <div th:if="${message}" class="alert alert-info alert-dismissible fade show mt-3" role="alert">
+                <span th:text="${message}">완료</span>
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+
+            <form class="needs-validation col-sm-6" action="#" th:action="@{/email-login}" method="post" novalidate>
+                <div class="form-group">
+                    <label for="email">가입 할 때 사용한 이메일</label>
+                    <input id="email" type="email" name="email" class="form-control"
+                           placeholder="your@email.com" aria-describedby="emailHelp" required>
+                    <small id="emailHelp" class="form-text text-muted">
+                        가입할 때 사용한 이메일을 입력하세요.
+                    </small>
+                    <small class="invalid-feedback">이메일을 입력하세요.</small>
+                </div>
+
+                <div class="form-group">
+                    <button class="btn btn-success btn-block" type="submit"
+                            aria-describedby="submitHelp">로그인 링크 보내기</button>
+                    <small id="submitHelp" class="form-text text-muted">
+                        스터디올래에 처음 오신거라면 <a href="#" th:href="@{/findpassword}">계정을 먼저 만드세요.</a>
+                    </small>
+                </div>
+            </form>
+        </div>
+
+        <div th:replace="fragments.html :: footer"></div>
+    </div>
+    <script th:replace="fragments.html :: form-validation"></script>
+</body>
+</html>

--- a/src/main/resources/templates/account/logged-in-by-email.html
+++ b/src/main/resources/templates/account/logged-in-by-email.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments.html :: head"></head>
+<body class="bg-light">
+    <nav th:replace="fragments.html :: main-nav"></nav>
+
+    <div class="container">
+        <div class="py-5 text-center" th:if="${error}">
+            <p class="lead">스터디올래 이메일 로그인</p>
+            <div  class="alert alert-danger" role="alert" th:text="${error}">
+                로그인 할 수 없습니다.
+            </div>
+        </div>
+
+        <div class="py-5 text-center" th:if="${error == null}">
+            <p class="lead">스터디올래 이메일 로그인</p>
+            <h2>이메일로 로그인 했습니다. <a th:href="@{/settings/password}">패스워드를 변경</a>하세요.</h2>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -39,7 +39,7 @@
                 <input id="password" type="password" name="password" class="form-control"
                        aria-describedby="passwordHelp" required>
                 <small id="passwordHelp" class="form-text text-muted">
-                    패스워드가 기억나지 않는다면, <a href="#" th:href="@{/emaillogin}">패스워드 없이 로그인하기</a>
+                    패스워드가 기억나지 않는다면, <a href="#" th:href="@{/email-login}">패스워드 없이 로그인하기</a>
                 </small>
                 <small class="invalid-feedback">패스워드를 입력하세요.</small>
             </div>


### PR DESCRIPTION
패스워드를 잊은 경우에는 “로그인 할 수 있는 링크”를 이메일로 전송한다.

이메일로 전송된 링크를 클릭하면 로그인한다.

GET /email-login
- 이메일을 입력할 수 있는 폼을 보여주고, 링크 전송 버튼을 제공한다.

POST /email-login
- 입력받은 이메일에 해당하는 계정을 찾아보고, 있는 계정이면 로그인 가능한 링크를 이메일로 전송한다.
- 이메일 전송 후, 안내 메시지를 보여준다.

GET /login-by-email
- 토큰과 이메일을 확인한 뒤 해당 계정으로 로그인한다.